### PR TITLE
Updated README to reflect Ember 1.10 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Simple Internationalization support for ember-cli apps.
 
-**Note: This release requires Ember 1.9. Will likely break with 1.10**
+**Note: This release requires Ember 1.10.**
 
 ## Install ##
 


### PR DESCRIPTION
Just was testing `v0.0.5` and `master` with an Ember CLI app using Ember 1.9.1  Both of those require Ember 1.10 instead of Ember 1.9.